### PR TITLE
Display all 5 hobbies in single row and fix profile image extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
                 </div>
             </div>
             <div class="hero-photo">
-                <img src="images/profile.jpg" alt="Celina Hyunsoo Park">
+                <img src="images/profile.png" alt="Celina Hyunsoo Park">
             </div>
         </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -349,8 +349,8 @@ body {
 
 .hobbies-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 1.5rem;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 1rem;
 }
 
 .hobby-card {
@@ -368,15 +368,16 @@ body {
 
 .hobby-card h3 {
     color: var(--primary-color);
-    padding: 1.25rem 1.25rem 0.5rem;
-    font-size: 1.1rem;
+    padding: 0.75rem 0.75rem 0.25rem;
+    font-size: 0.95rem;
     font-weight: 600;
 }
 
 .hobby-card p {
-    padding: 0 1.25rem 1.25rem;
+    padding: 0 0.75rem 0.75rem;
     color: var(--text-light);
-    font-size: 0.95rem;
+    font-size: 0.8rem;
+    line-height: 1.4;
 }
 
 .hobby-image-placeholder {
@@ -488,7 +489,7 @@ body {
     }
 
     .hobbies-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(3, 1fr);
     }
 }
 
@@ -519,5 +520,9 @@ body {
     .hero-buttons {
         flex-direction: column;
         gap: 1rem;
+    }
+
+    .hobbies-grid {
+        grid-template-columns: repeat(2, 1fr);
     }
 }


### PR DESCRIPTION
- Change hobbies grid to 5-column layout for desktop
- Reduce hobby card text sizes for narrower cards
- Fix profile photo extension from .jpg to .png
- Add responsive breakpoints: 3 columns for tablet, 2 columns for mobile